### PR TITLE
DAT-5700: Change dockerfile to get liquibase from jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,12 @@ RUN ln -s /liquibase/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh \
 USER liquibase
 
 # Latest Liquibase Release Version
-ARG LIQUIBASE_VERSION=4.2.2
+ARG LIQUIBASE_VERSION=liquibase-4.3.0-DAT-5700-SNAPSHOT
 
 # Download, verify, extract
-ARG LB_SHA256=807ef4b514d01fc62f7aaf4150a8435c90ccb5986f3272d3cfd1bd26c2cf7b4c
 RUN set -x \
-  && wget -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" \
-  && echo "$LB_SHA256  liquibase-${LIQUIBASE_VERSION}.tar.gz" | sha256sum -c - \
+  && wget -O liquibase-${LIQUIBASE_VERSION}.tar.gz "https://jenkins.datical.net/job/liquibase-pro/job/DAT-5700/13/artifact/liquibase/liquibase-dist/target/${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz" \
+  && echo liquibase-${LIQUIBASE_VERSION}.tar.gz" \
   && tar -xzf liquibase-${LIQUIBASE_VERSION}.tar.gz \
   && rm liquibase-${LIQUIBASE_VERSION}.tar.gz
 


### PR DESCRIPTION
Merging changes into main of my fork. Seems like unless I do a release (to get tag), the liquibase-github-action job only looks at main. Maybe?